### PR TITLE
Image display API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@
 /.project
 /.settings/
 /target/
+
+.idea
+*.iml

--- a/pom.xml
+++ b/pom.xml
@@ -7,13 +7,13 @@
 	<parent>
 		<groupId>org.scijava</groupId>
 		<artifactId>pom-scijava</artifactId>
-		<version>18.0.0</version>
+		<version>23.1.1</version>
 		<relativePath />
 	</parent>
 
 	<groupId>net.imagej</groupId>
 	<artifactId>imagej-notebook</artifactId>
-	<version>0.2.4-SNAPSHOT</version>
+	<version>0.3.0-SNAPSHOT</version>
 
 	<name>ImageJ Notebook</name>
 	<description>Functions for working with ImageJ in scientific notebook software.</description>
@@ -87,6 +87,9 @@
 		<releaseProfiles>deploy-to-imagej</releaseProfiles>
 		<jvm-repr.version>0.2.1</jvm-repr.version>
 		<beaker-kernel-base.version>1.0.0</beaker-kernel-base.version>
+
+		<!-- NB: antlr-runtime depends on treelayout but shadows some classes -->
+		<allowedDuplicateClasses>org.abego.treelayout.*</allowedDuplicateClasses>
 	</properties>
 
 	<repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
 	<parent>
@@ -77,11 +79,14 @@
 
 		<license.licenseName>bsd_2</license.licenseName>
 		<license.copyrightOwners>Board of Regents of the University of
-Wisconsin-Madison.</license.copyrightOwners>
-		<license.projectName>ImageJ software for multidimensional image processing and analysis.</license.projectName>
+			Wisconsin-Madison.</license.copyrightOwners>
+		<license.projectName>ImageJ software for multidimensional image
+			processing and analysis.</license.projectName>
 
 		<!-- NB: Deploy releases to the ImageJ Maven repository. -->
 		<releaseProfiles>deploy-to-imagej</releaseProfiles>
+		<jvm-repr.version>0.2.1</jvm-repr.version>
+		<beaker-kernel-base.version>1.0.0</beaker-kernel-base.version>
 	</properties>
 
 	<repositories>
@@ -112,6 +117,17 @@ Wisconsin-Madison.</license.copyrightOwners>
 		<dependency>
 			<groupId>org.scijava</groupId>
 			<artifactId>scijava-common</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>com.github.twosigma.beakerx</groupId>
+			<artifactId>beaker-kernel-base</artifactId>
+			<version>${beaker-kernel-base.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>com.github.jupyter</groupId>
+			<artifactId>jvm-repr</artifactId>
+			<version>${jvm-repr.version}</version>
 		</dependency>
 
 		<!-- Test scope dependencies -->

--- a/src/main/java/net/imagej/notebook/DefaultNotebookService.java
+++ b/src/main/java/net/imagej/notebook/DefaultNotebookService.java
@@ -7,13 +7,13 @@
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
- * 
+ *
  * 1. Redistributions of source code must retain the above copyright notice,
  *    this list of conditions and the following disclaimer.
  * 2. Redistributions in binary form must reproduce the above copyright notice,
  *    this list of conditions and the following disclaimer in the documentation
  *    and/or other materials provided with the distribution.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
@@ -30,14 +30,25 @@
 
 package net.imagej.notebook;
 
+import com.twosigma.beakerx.mimetype.MIMEContainer;
+import com.twosigma.beakerx.util.Images;
+
+import java.awt.image.BufferedImage;
+import java.awt.image.RenderedImage;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.StringWriter;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Comparator;
+import java.util.Base64;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 import net.imagej.display.ColorTables;
+import net.imagej.display.DatasetView;
 import net.imagej.ops.OpService;
 import net.imagej.ops.Ops;
 import net.imagej.ops.special.inplace.Inplaces;
@@ -46,6 +57,7 @@ import net.imglib2.IterableInterval;
 import net.imglib2.RandomAccessible;
 import net.imglib2.RandomAccessibleInterval;
 import net.imglib2.converter.Converter;
+import net.imglib2.converter.Converters;
 import net.imglib2.converter.RealLUTConverter;
 import net.imglib2.display.ColorTable8;
 import net.imglib2.display.projector.composite.CompositeXYProjector;
@@ -58,12 +70,16 @@ import net.imglib2.util.IntervalIndexer;
 import net.imglib2.util.Pair;
 import net.imglib2.util.Util;
 import net.imglib2.view.IntervalView;
+import net.imglib2.view.Views;
 
 import org.scijava.plugin.Parameter;
 import org.scijava.plugin.Plugin;
 import org.scijava.service.AbstractService;
 import org.scijava.service.Service;
 import org.scijava.util.ClassUtils;
+
+import jupyter.Displayer;
+import jupyter.Displayers;
 
 /**
  * AWT-driven implementation of {@link NotebookService}.
@@ -79,10 +95,92 @@ public class DefaultNotebookService extends AbstractService implements
 	private OpService ops;
 
 	@Override
+	public void initialize() {
+		register(RandomAccessibleInterval.class, (map, image) -> {
+			map.put(MIMEContainer.MIME.IMAGE_PNG, encodeImage(image));
+		});
+
+		register(DatasetView.class, (map, imageView) -> {
+			map.put(MIMEContainer.MIME.IMAGE_PNG, //
+				base64(imageView.getScreenImage().image()));
+		});
+	}
+
+	// -- Helper methods for specific types being displayed --
+
+	@SuppressWarnings({ "rawtypes", "unchecked" })
+	private String encodeImage(final RandomAccessibleInterval<?> image)
+		throws IOException
+	{
+		final Object element = Util.getTypeFromInterval(image);
+
+		if (element instanceof ARGBType) {
+			return encodeARGBTypeImage((RandomAccessibleInterval) image);
+		}
+		else if (element instanceof RealType) {
+			return encodeRealTypeImage((RandomAccessibleInterval) image);
+		}
+		else {
+			throw new IllegalArgumentException("Unsupported image type: " + element
+				.getClass().getName());
+		}
+	}
+
+	private String encodeARGBTypeImage(
+		final RandomAccessibleInterval<ARGBType> image) throws IOException
+	{
+		// NB: ignoring alpha
+		return encodeRealTypeImage(Converters.argbChannels(image, 1, 2, 3));
+	}
+
+	private <T extends RealType<T>> String encodeRealTypeImage(
+		final RandomAccessibleInterval<T> image) throws IOException
+	{
+		final BufferedImage bi = (BufferedImage) DefaultNotebookService.this
+			.display(image);
+		return base64(bi);
+	}
+
+	private String base64(final RenderedImage image) throws IOException {
+		final byte[] data = Images.encode(image);
+		return Base64.getEncoder().encodeToString(data);
+	}
+
+	// -- Registration machinery --
+
+	public interface DisplayerPopulator<T> {
+
+		void populate(Map<String, String> map, T object) throws Exception;
+	}
+
+	public static <T> void register(final Class<T> clazz,
+		final DisplayerPopulator<T> populator)
+	{
+		Displayers.register(clazz, new Displayer<T>() {
+
+			@Override
+			public Map<String, String> display(final T object) {
+				final HashMap<String, String> m = new HashMap<>();
+				try {
+					populator.populate(m, object);
+				}
+				catch (final Exception exc) {
+					final StringWriter sw = new StringWriter();
+					exc.printStackTrace(new PrintWriter(sw));
+					m.put(MIMEContainer.MIME.TEXT_HTML, "<div><pre>" + sw.toString() +
+						"</pre></div>");
+				}
+				return m;
+			}
+		});
+	}
+
+	// -- Public API --
+
+	@Override
 	public <T extends RealType<T>> Object display(
-		final RandomAccessibleInterval<T> source, //
-		final int xAxis, final int yAxis, final int cAxis, //
-		final ValueScaling scaling, final long... pos)
+		final RandomAccessibleInterval<T> source, final int xAxis, final int yAxis,
+		final int cAxis, final double[] min, final double[] max, final long... pos)
 	{
 		final IntervalView<T> image = ops.transform().zeroMinView(source);
 
@@ -92,14 +190,40 @@ public class DefaultNotebookService extends AbstractService implements
 		final ARGBScreenImage target = new ARGBScreenImage(w, h);
 		final ArrayList<Converter<T, ARGBType>> converters = new ArrayList<>(c);
 
+		if (min.length != c || max.length != c) throw new IllegalArgumentException(
+			"clamping arrays must be of the same length as the number of channels!");
+
+		for (int i = 0; i < c; i++) {
+			final ColorTable8 lut = c == 1 ? //
+				ColorTables.GRAYS : ColorTables.getDefaultColorTable(i);
+			converters.add(new RealLUTConverter<T>(min[i], max[i], lut));
+		}
+		final CompositeXYProjector<T> proj = new CompositeXYProjector<>(image,
+			target, converters, cAxis);
+		if (pos != null && pos.length > 0) proj.setPosition(pos);
+		proj.setComposite(true);
+		proj.map();
+
+		return target.image();
+
+	}
+
+	@Override
+	public <T extends RealType<T>> Object display(
+		final RandomAccessibleInterval<T> source, //
+		final int xAxis, final int yAxis, final int cAxis, //
+		final ValueScaling scaling, final long... pos)
+	{
 		final double min, max;
 		final boolean full = scaling == ValueScaling.FULL || //
 			scaling == ValueScaling.AUTO && isNarrowType(source);
 
+		final T firstElement = Views.iterable(source).firstElement();
+
 		if (full) {
 			// scale the intensities based on the full range of the type
-			min = image.firstElement().getMinValue();
-			max = image.firstElement().getMaxValue();
+			min = firstElement.getMinValue();
+			max = firstElement.getMaxValue();
 		}
 		else {
 			// scale the intensities based on the sample values
@@ -109,17 +233,16 @@ public class DefaultNotebookService extends AbstractService implements
 			max = minMax.getB().getRealDouble();
 		}
 
-		for (int i = 0; i < c; i++) {
-			final ColorTable8 lut = c == 1 ? //
-				ColorTables.GRAYS : ColorTables.getDefaultColorTable(i);
-			converters.add(new RealLUTConverter<T>(min, max, lut));
+		// create arrays from generated min/max
+		final int arraySize = cAxis >= 0 ? (int) source.dimension(cAxis) : 1;
+		final double[] minArray = new double[arraySize];
+		final double[] maxArray = new double[arraySize];
+		for (int i = 0; i < minArray.length; i++) {
+			minArray[i] = min;
+			maxArray[i] = max;
 		}
-		final CompositeXYProjector<T> proj = new CompositeXYProjector<>(image,
-			target, converters, cAxis);
-		if (pos != null && pos.length > 0) proj.setPosition(pos);
-		proj.setComposite(true);
-		proj.map();
-		return target.image();
+
+		return display(source, xAxis, yAxis, cAxis, minArray, maxArray, pos);
 	}
 
 	@Override
@@ -193,12 +316,14 @@ public class DefaultNotebookService extends AbstractService implements
 			for (int d = 0; d < numDims; d++)
 				offset[d] = offsets[d][pos[d]];
 			final IntervalView<T> translated = //
-				ops.transform().translateView(ops.transform().zeroMinView(images[i]), offset);
+				ops.transform().translateView(ops.transform().zeroMinView(images[i]),
+					offset);
 
 			// Declare that all values outside the interval proper will be 0.
 			// If we do not perform this step, we will get an error when querying
 			// out-of-bounds coordinates.
-			final RandomAccessible<T> extended = ops.transform().extendZeroView(translated);
+			final RandomAccessible<T> extended = ops.transform().extendZeroView(
+				translated);
 
 			// Define the interval of the image to match the size of the mosaic.
 			final RandomAccessibleInterval<T> expanded = //
@@ -219,23 +344,19 @@ public class DefaultNotebookService extends AbstractService implements
 
 		final Method[] methods = type.getMethods();
 		// NB: Methods are returned in inconsistent order.
-		Arrays.sort(methods, new Comparator<Method>() {
-
-			@Override
-			public int compare(final Method m1, final Method m2) {
-				final int nameComp = m1.getName().compareTo(m2.getName());
-				if (nameComp != 0) return nameComp;
-				final int pCount1 = m1.getParameterCount();
-				final int pCount2 = m2.getParameterCount();
-				if (pCount1 != pCount2) return pCount1 - pCount2;
-				final Class<?>[] pTypes1 = m1.getParameterTypes();
-				final Class<?>[] pTypes2 = m2.getParameterTypes();
-				for (int i = 0; i < pTypes1.length; i++) {
-					final int typeComp = ClassUtils.compare(pTypes1[i], pTypes2[i]);
-					if (typeComp != 0) return typeComp;
-				}
-				return ClassUtils.compare(m1.getReturnType(), m2.getReturnType());
+		Arrays.sort(methods, (m1, m2) -> {
+			final int nameComp = m1.getName().compareTo(m2.getName());
+			if (nameComp != 0) return nameComp;
+			final int pCount1 = m1.getParameterCount();
+			final int pCount2 = m2.getParameterCount();
+			if (pCount1 != pCount2) return pCount1 - pCount2;
+			final Class<?>[] pTypes1 = m1.getParameterTypes();
+			final Class<?>[] pTypes2 = m2.getParameterTypes();
+			for (int i = 0; i < pTypes1.length; i++) {
+				final int typeComp = ClassUtils.compare(pTypes1[i], pTypes2[i]);
+				if (typeComp != 0) return typeComp;
 			}
+			return ClassUtils.compare(m1.getReturnType(), m2.getReturnType());
 		});
 
 		for (final Method m : methods) {
@@ -268,4 +389,5 @@ public class DefaultNotebookService extends AbstractService implements
 	{
 		return Util.getTypeFromInterval(source).getBitsPerPixel() <= 8;
 	}
+
 }


### PR DESCRIPTION
This PR migrates `RAI` rendering in notebooks from [scijava-jupyter-kernel](https://github.com/scijava/scijava-jupyter-kernel) to the [BeakerX](https://github.com/twosigma/beakerx) kernel. The original `display()` APIs are kept and a couple more general ones are added.
See https://github.com/imagej/imagej-notebook/issues/6