### PR TITLE
Notebook views

### DIFF
--- a/src/main/java/net/imagej/notebook/DefaultNotebookService.java
+++ b/src/main/java/net/imagej/notebook/DefaultNotebookService.java
@@ -35,6 +35,12 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import net.imagej.Data;
+import net.imagej.DatasetService;
+import net.imagej.axis.Axes;
+import net.imagej.display.DataView;
+import net.imagej.display.DefaultDatasetView;
+import net.imagej.display.ImageDisplayService;
 import net.imagej.notebook.mime.MIMEObject;
 import net.imagej.ops.OpService;
 import net.imagej.ops.Ops;
@@ -42,8 +48,10 @@ import net.imagej.ops.special.inplace.Inplaces;
 import net.imglib2.FinalInterval;
 import net.imglib2.RandomAccessible;
 import net.imglib2.RandomAccessibleInterval;
+import net.imglib2.converter.Converters;
 import net.imglib2.img.Img;
 import net.imglib2.type.NativeType;
+import net.imglib2.type.numeric.ARGBType;
 import net.imglib2.type.numeric.RealType;
 import net.imglib2.util.IntervalIndexer;
 import net.imglib2.util.Util;
@@ -68,6 +76,12 @@ public class DefaultNotebookService extends AbstractService implements
 
 	@Parameter
 	private ConvertService convertService;
+	
+	@Parameter
+	private ImageDisplayService ids;
+	
+	@Parameter
+	private DatasetService ds;
 
 	@Parameter
 	private OpService ops;
@@ -245,6 +259,65 @@ public class DefaultNotebookService extends AbstractService implements
 			);
 		}
 		return table;
+	}
+	
+	@Override
+	@SuppressWarnings({"unchecked", "rawtypes"})
+	public DefaultDatasetView view(final RandomAccessibleInterval<?> source) {
+
+		final Object element = Util.getTypeFromInterval(source);
+		if (element instanceof ARGBType) {
+			return viewRealType(Converters.argbChannels(
+				(RandomAccessibleInterval<ARGBType>) source, 1, 2, 3));
+		}
+		else if (element instanceof RealType) {
+			return viewRealType((RandomAccessibleInterval<RealType>) source);
+		}
+		else {
+			throw new IllegalArgumentException("Unsupported image type: " + element
+				.getClass().getName());
+		}
+	}
+
+	@Override
+	public DefaultDatasetView view(final RandomAccessibleInterval<?> source,
+		final double min, final double max)
+	{
+		DefaultDatasetView output = view(source);
+		output.setChannelRanges(min, max);
+		output.rebuild();
+		return output;
+	}
+
+	@Override
+	public DefaultDatasetView view(final RandomAccessibleInterval<?> source,
+		final double[] min, final double[] max)
+	{
+
+		if (min.length < source.numDimensions() || max.length < source
+			.numDimensions()) throw new IllegalArgumentException(
+				"Channel maximum and minimum arrays do not match image dimensions!");
+
+		DefaultDatasetView output = view(source);
+
+		for (int c = 0; c < output.getData().dimension(Axes.CHANNEL); c++) {
+			output.setChannelRange(c, min[c], max[c]);
+		}
+
+		output.rebuild();
+		return output;
+	}
+
+	private <T extends RealType<T>> DefaultDatasetView viewRealType(
+		final RandomAccessibleInterval<T> source)
+	{
+		Data data = ds.create(source);
+		DataView view = ids.createDataView(data);
+		if (!(view instanceof DefaultDatasetView))
+			throw new IllegalArgumentException(
+				"source image cannot be cast to a DefaultDataset");
+		DefaultDatasetView datasetView = (DefaultDatasetView) view;
+		return datasetView;
 	}
 
 	// -- Helper methods --

--- a/src/main/java/net/imagej/notebook/DefaultNotebookService.java
+++ b/src/main/java/net/imagej/notebook/DefaultNotebookService.java
@@ -37,9 +37,8 @@ import java.util.stream.Collectors;
 
 import net.imagej.Data;
 import net.imagej.DatasetService;
-import net.imagej.axis.Axes;
 import net.imagej.display.DataView;
-import net.imagej.display.DefaultDatasetView;
+import net.imagej.display.DatasetView;
 import net.imagej.display.ImageDisplayService;
 import net.imagej.notebook.mime.MIMEObject;
 import net.imagej.ops.OpService;
@@ -48,10 +47,8 @@ import net.imagej.ops.special.inplace.Inplaces;
 import net.imglib2.FinalInterval;
 import net.imglib2.RandomAccessible;
 import net.imglib2.RandomAccessibleInterval;
-import net.imglib2.converter.Converters;
 import net.imglib2.img.Img;
 import net.imglib2.type.NativeType;
-import net.imglib2.type.numeric.ARGBType;
 import net.imglib2.type.numeric.RealType;
 import net.imglib2.util.IntervalIndexer;
 import net.imglib2.util.Util;
@@ -262,61 +259,15 @@ public class DefaultNotebookService extends AbstractService implements
 	}
 	
 	@Override
-	@SuppressWarnings({"unchecked", "rawtypes"})
-	public DefaultDatasetView view(final RandomAccessibleInterval<?> source) {
-
-		final Object element = Util.getTypeFromInterval(source);
-		if (element instanceof ARGBType) {
-			return viewRealType(Converters.argbChannels(
-				(RandomAccessibleInterval<ARGBType>) source, 1, 2, 3));
-		}
-		else if (element instanceof RealType) {
-			return viewRealType((RandomAccessibleInterval<RealType>) source);
-		}
-		else {
-			throw new IllegalArgumentException("Unsupported image type: " + element
-				.getClass().getName());
-		}
-	}
-
-	@Override
-	public DefaultDatasetView view(final RandomAccessibleInterval<?> source,
-		final double min, final double max)
-	{
-		DefaultDatasetView output = view(source);
-		output.setChannelRanges(min, max);
-		output.rebuild();
-		return output;
-	}
-
-	@Override
-	public DefaultDatasetView view(final RandomAccessibleInterval<?> source,
-		final double[] min, final double[] max)
-	{
-
-		if (min.length < source.numDimensions() || max.length < source
-			.numDimensions()) throw new IllegalArgumentException(
-				"Channel maximum and minimum arrays do not match image dimensions!");
-
-		DefaultDatasetView output = view(source);
-
-		for (int c = 0; c < output.getData().dimension(Axes.CHANNEL); c++) {
-			output.setChannelRange(c, min[c], max[c]);
-		}
-
-		output.rebuild();
-		return output;
-	}
-
-	private <T extends RealType<T>> DefaultDatasetView viewRealType(
+	public <T extends RealType<T>> DatasetView viewRealType(
 		final RandomAccessibleInterval<T> source)
 	{
 		Data data = ds.create(source);
 		DataView view = ids.createDataView(data);
-		if (!(view instanceof DefaultDatasetView))
+		if (!(view instanceof DatasetView))
 			throw new IllegalArgumentException(
-				"source image cannot be cast to a DefaultDataset");
-		DefaultDatasetView datasetView = (DefaultDatasetView) view;
+				"source image cannot be cast to a DatasetView");
+		DatasetView datasetView = (DatasetView) view;
 		return datasetView;
 	}
 

--- a/src/main/java/net/imagej/notebook/NotebookService.java
+++ b/src/main/java/net/imagej/notebook/NotebookService.java
@@ -36,6 +36,7 @@ import java.util.Map;
 
 import net.imagej.Dataset;
 import net.imagej.ImageJService;
+import net.imagej.display.DefaultDatasetView;
 import net.imglib2.RandomAccessibleInterval;
 import net.imglib2.type.NativeType;
 import net.imglib2.type.numeric.RealType;
@@ -394,4 +395,39 @@ public interface NotebookService extends ImageJService {
 	 * @return a table of the class's public methods.
 	 */
 	NotebookTable methods(Class<?> type, String prefix);
+	
+	/**
+	 * Conveniently wraps a {@link RandomAccessibleInterval} into a
+	 * {@link DefaultDatasetView}.
+	 * 
+	 * @param source - the input data
+	 * @return a DefaultDatasetView containing the data
+	 */
+	DefaultDatasetView view(final RandomAccessibleInterval<?> source);
+
+	/**
+	 * Conveniently wraps a {@link RandomAccessibleInterval} into a
+	 * {@link DefaultDatasetView} and presets the channel ranges to the given
+	 * minimum and maximum values.
+	 * 
+	 * @param source - the input data
+	 * @param min - the minimum for the channel ranges
+	 * @param max - the maximum for the channel ranges
+	 * @return a DefaultDatasetView containing the data
+	 */
+	DefaultDatasetView view(final RandomAccessibleInterval<?> source,
+		final double min, final double max);
+
+	/**
+	 * Conveniently wraps a {@link RandomAccessibleInterval} into a
+	 * {@link DefaultDatasetView} and presets the channel ranges to the given
+	 * minimum and maximum arrays.
+	 * 
+	 * @param source - the input data
+	 * @param min - the minimum for the channel ranges
+	 * @param max - the maximum for the channel ranges
+	 * @return a DefaultDatasetView containing the data
+	 */
+	DefaultDatasetView view(final RandomAccessibleInterval<?> source,
+		final double[] min, final double[] max);
 }

--- a/src/main/java/net/imagej/notebook/NotebookService.java
+++ b/src/main/java/net/imagej/notebook/NotebookService.java
@@ -36,10 +36,15 @@ import java.util.Map;
 
 import net.imagej.Dataset;
 import net.imagej.ImageJService;
+import net.imagej.axis.Axes;
+import net.imagej.display.DatasetView;
 import net.imagej.display.DefaultDatasetView;
 import net.imglib2.RandomAccessibleInterval;
+import net.imglib2.converter.Converters;
 import net.imglib2.type.NativeType;
+import net.imglib2.type.numeric.ARGBType;
 import net.imglib2.type.numeric.RealType;
+import net.imglib2.util.Util;
 
 import org.scijava.table.Tables;
 
@@ -403,7 +408,22 @@ public interface NotebookService extends ImageJService {
 	 * @param source - the input data
 	 * @return a DefaultDatasetView containing the data
 	 */
-	DefaultDatasetView view(final RandomAccessibleInterval<?> source);
+	@SuppressWarnings({ "unchecked", "rawtypes" })
+	default DatasetView view(final RandomAccessibleInterval<?> source) {
+
+		final Object element = Util.getTypeFromInterval(source);
+		if (element instanceof ARGBType) {
+			return viewRealType(Converters.argbChannels(
+				(RandomAccessibleInterval<ARGBType>) source, 1, 2, 3));
+		}
+		else if (element instanceof RealType) {
+			return viewRealType((RandomAccessibleInterval<RealType>) source);
+		}
+		else {
+			throw new IllegalArgumentException("Unsupported image type: " + element
+				.getClass().getName());
+		}
+	}
 
 	/**
 	 * Conveniently wraps a {@link RandomAccessibleInterval} into a
@@ -415,8 +435,14 @@ public interface NotebookService extends ImageJService {
 	 * @param max - the maximum for the channel ranges
 	 * @return a DefaultDatasetView containing the data
 	 */
-	DefaultDatasetView view(final RandomAccessibleInterval<?> source,
-		final double min, final double max);
+	default DatasetView view(final RandomAccessibleInterval<?> source,
+		final double min, final double max)
+	{
+		DatasetView output = view(source);
+		output.setChannelRanges(min, max);
+		output.rebuild();
+		return output;
+	}
 
 	/**
 	 * Conveniently wraps a {@link RandomAccessibleInterval} into a
@@ -428,6 +454,32 @@ public interface NotebookService extends ImageJService {
 	 * @param max - the maximum for the channel ranges
 	 * @return a DefaultDatasetView containing the data
 	 */
-	DefaultDatasetView view(final RandomAccessibleInterval<?> source,
-		final double[] min, final double[] max);
+	default DatasetView view(final RandomAccessibleInterval<?> source,
+		final double[] min, final double[] max)
+	{
+
+		if (min.length < source.numDimensions() || max.length < source
+			.numDimensions()) throw new IllegalArgumentException(
+				"Channel maximum and minimum arrays do not match image dimensions!");
+
+		DatasetView output = view(source);
+
+		for (int c = 0; c < output.getData().dimension(Axes.CHANNEL); c++) {
+			output.setChannelRange(c, min[c], max[c]);
+		}
+
+		output.rebuild();
+		return output;
+	}
+
+	/**
+	 * Conveniently wraps a {@link RandomAccessibleInterval} of {@link RealType}
+	 * into a {@link DefaultDatasetView} and presets the channel ranges to the
+	 * given minimum and maximum arrays.
+	 * 
+	 * @param source - the input data
+	 * @return a DefaultDatasetView containing the data
+	 */
+	<T extends RealType<T>> DatasetView viewRealType(
+		final RandomAccessibleInterval<T> source);
 }

--- a/src/test/java/net/imagej/notebook/NotebookServiceTest.java
+++ b/src/test/java/net/imagej/notebook/NotebookServiceTest.java
@@ -39,7 +39,7 @@ import java.util.LinkedHashMap;
 import net.imagej.Dataset;
 import net.imagej.DatasetService;
 import net.imagej.autoscale.AutoscaleService;
-import net.imagej.display.DefaultDatasetView;
+import net.imagej.display.DatasetView;
 import net.imglib2.Cursor;
 import net.imglib2.RandomAccessibleInterval;
 import net.imglib2.img.array.ArrayImg;
@@ -141,7 +141,7 @@ public class NotebookServiceTest {
 	@Test
 	public void testViewImg() {
 		final ArrayImg<UnsignedByteType, ByteArray> img = createTestImg();
-		final DefaultDatasetView dataset = ns.view(img);
+		final DatasetView dataset = ns.view(img);
 		dataset.rebuild();
 		assertSameImageDetails(img, dataset.getScreenImage().image());
 	}

--- a/src/test/java/net/imagej/notebook/NotebookServiceTest.java
+++ b/src/test/java/net/imagej/notebook/NotebookServiceTest.java
@@ -38,6 +38,8 @@ import java.util.LinkedHashMap;
 
 import net.imagej.Dataset;
 import net.imagej.DatasetService;
+import net.imagej.autoscale.AutoscaleService;
+import net.imagej.display.DefaultDatasetView;
 import net.imglib2.Cursor;
 import net.imglib2.RandomAccessibleInterval;
 import net.imglib2.img.array.ArrayImg;
@@ -63,7 +65,7 @@ public class NotebookServiceTest {
 
 	@Before
 	public void setUp() {
-		context = new Context(NotebookService.class, DatasetService.class);
+		context = new Context(NotebookService.class, DatasetService.class, AutoscaleService.class);
 		ns = context.service(NotebookService.class);
 		ds = context.service(DatasetService.class);
 	}
@@ -134,6 +136,14 @@ public class NotebookServiceTest {
 
 		final Object rendered = ns.display(actual, min, max);
 		assertSameImageDetails(expected, rendered);
+	}
+	
+	@Test
+	public void testViewImg() {
+		final ArrayImg<UnsignedByteType, ByteArray> img = createTestImg();
+		final DefaultDatasetView dataset = ns.view(img);
+		dataset.rebuild();
+		assertSameImageDetails(img, dataset.getScreenImage().image());
 	}
 
 	@Test


### PR DESCRIPTION
This PR adds convenience methods to create `DefaultDatasetView`s out of `RandomAccessibleInterval`s, which is nice for manipulating channel ranges, color tables, etc.

TODO:
* Do we need more tests (keeping in mind that we also have the notebooks to test out these methods)?